### PR TITLE
Adding the ability to check if Supply SIgnals/Helis are player owned

### DIFF
--- a/Imperium.cs
+++ b/Imperium.cs
@@ -32,6 +32,7 @@ namespace Oxide.Plugins
     using UnityEngine;
     using System.Collections.Generic;
     using System.Linq;
+    using Oxide.Core.Plugins;
     using Network;
 
     [Info("Imperium", "chucklenugget/evict", "2.2.7")]

--- a/Imperium.cs
+++ b/Imperium.cs
@@ -3862,27 +3862,31 @@ namespace Oxide.Plugins
         void OnExplosiveThrown(BasePlayer player, SupplySignal supplySignal, ThrownWeapon thrownWeapon)
         {
             supplySignal.OwnerID = player.userID;
-            Puts($"Setting supply signal owner id");
+            //debug info
+            //Puts($"Setting supply signal owner id");
         }
 
         void OnCargoPlaneSignaled(CargoPlane cargoPlane, SupplySignal supplySignal)
         {
             cargoPlane.OwnerID = supplySignal.OwnerID;
-            Puts($"Setting cargo plane owner to supply signal's id");
+            //debug info
+            //Puts($"Setting cargo plane owner to supply signal's id");
         }
 
         void OnSupplyDropDropped(SupplyDrop drop, CargoPlane cargoPlane)
         {
             if (cargoPlane.OwnerID == 0)
             {
-                Puts("Cargo plane's ownerID is 0.");
-                Puts("Either server drop, or code is broken");
+                //debug info
+                //Puts("Cargo plane's ownerID is 0.");
+                //Puts("Either server drop, or code is broken");
                 if (Options.Zones.Enabled && drop != null)
                     Zones.CreateForSupplyDrop(drop);
             }
             else
             {
-                Puts($"Cargo plane had owner ID - Must be a player signalled drop");
+                //debug info
+                //Puts($"Cargo plane had owner ID - Must be a player signalled drop");
             }
         }
         #endregion


### PR DESCRIPTION
This will check if the player threw a Supply Signal or if the Helis are owned by a player, added the config option to allow or restrict the ability to create a PvP zone if the Helicopter (Attack/Mini/scrap) are allowed to create a debris zone for PvP. Same for the Supply Signal.